### PR TITLE
Explicitly specify return type of getValue function

### DIFF
--- a/index.js
+++ b/index.js
@@ -485,7 +485,7 @@ function printPlugin(value, stack, env, refs, depth) {
   return true;
 }
 
-function printValue(value, stack, env, refs, depth) {
+function printValue(value, stack, env, refs, depth)/*: string | void */ {
   if (env.opts.plugins.length) {
     let printed = printPlugin(value, stack, env, refs, depth);
     if (printed) return;


### PR DESCRIPTION
Later versions of Flow get into an infinite loop trying to work out what the return type of the recursive getValue function is. I wasn't 100% sure what type this function returns, but string or nothing looks to have done the trick.